### PR TITLE
Add support for {} imports

### DIFF
--- a/multisol-collector/src/lib.rs
+++ b/multisol-collector/src/lib.rs
@@ -17,7 +17,7 @@ use multisol_structs::Contract;
 
 // The lazy init ensures that the regular expression is compiled exactly once.
 lazy_static! {
-    static ref IMPORT_REGEX: Regex = Regex::new("import ['\"](.*?.sol)['\"];").unwrap();
+    static ref IMPORT_REGEX: Regex = Regex::new("import (?:\\{[^{}]*\\} from )?['\"](.*?.sol)['\"];").unwrap();
 }
 
 /// Entry point to the crate.


### PR DESCRIPTION
Title is self-explanatory, this just adds support for imports of the type `import {Contract} from "something.sol";`